### PR TITLE
Fix chart-containers & typo

### DIFF
--- a/l10n/en.js
+++ b/l10n/en.js
@@ -14,7 +14,7 @@ const en = {
         emptySet: 'Data set is empty. Please, ensure map is selected correctly.'
     },
     maps: {
-        RU: 'Russia Federation',
+        RU: 'Russian Federation',
         UA: 'Ukraine',
         worldPalestine: 'World'
     }

--- a/src/zeppelin-highmaps.js
+++ b/src/zeppelin-highmaps.js
@@ -69,6 +69,14 @@ export default class ZeppelinHighmaps extends Visualization {
 
     /**
      * @override
+     */
+    refresh() {
+        this.redrawChart();
+    }
+
+
+    /**
+     * @override
      * @param {object[]} tableData Raw data.
      */
     render(tableData) {
@@ -197,6 +205,11 @@ export default class ZeppelinHighmaps extends Visualization {
      */
     createChartContainer() {
         // TBD: several maps for one data set.
+        if (this.targetEl[0].childElementCount > 0) {
+            while (this.targetEl[0].lastElementChild) {
+                this.targetEl[0].removeChild(this.targetEl[0].lastElementChild);
+            }
+        }
         const chartContainerHtml = `<div id="${this.instanceId}-chart-container" `
             + 'style="height: 100%; flex: 1; display: flex; flex-direction: row;" '
             + '></div>';
@@ -204,7 +217,6 @@ export default class ZeppelinHighmaps extends Visualization {
         this.targetEl.append(this.chartContainer);
         return this.chartContainer;
     }
-
 
     /**
      * Returns Angular definition for settings panel.


### PR DESCRIPTION
### What is this PR for?

* Running paragraph for a few times may produce plenty containers in the same output:
![bug_fix](https://user-images.githubusercontent.com/6136993/48095017-b2b97a00-e224-11e8-8025-5ea109934ba4.gif)
* Overriding method `refresh` removes [console warnings](https://github.com/apache/zeppelin/blob/master/zeppelin-web/src/app/visualization/visualization.js#L51) 

### What type of PR is it?
Bug Fix

### How should this be tested?
* Manually tested
